### PR TITLE
Update token-request.js

### DIFF
--- a/lib/token-request.js
+++ b/lib/token-request.js
@@ -120,7 +120,7 @@ TokenRequest.prototype._getTokenWithTokenResponse = function(entry, resource, ca
 
 TokenRequest.prototype._createCacheQuery = function() {
   var query = {
-    clientId : this._clientId
+    _clientId : this._clientId
   };
 
   if (this._userId) {


### PR DESCRIPTION
Metadata in cache that this queries starts with underscore so wasn't getting cache hits. Works for my use case but YMMV.